### PR TITLE
Use cryptape's libsm2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://github.com/cryptape/hasher/blob/master/README.md"
 [dependencies]
 tiny-keccak = { version = "1.4", optional = true }
 blake2b-rs = { version = "0.1", optional = true }
-libsm = { version = "0.3", optional = true }
+libsm = { git = "https://github.com/cryptape/libsm", rev = "4d0e6199fca0934c58131de1d0036e9aa4da26c1", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
Use cryptape's libsm2.
Test Result:
```shell
~/r/c/hasher> cargo test --all-features
   Compiling libsm v0.3.0 (https://github.com/cryptape/libsm?rev=4d0e6199fca0934c58131de1d0036e9aa4da26c1#4d0e6199)
   Compiling hasher v0.1.2 (/home/leeyr/rivtower/code/hasher)
    Finished dev [unoptimized + debuginfo] target(s) in 1.02s
     Running target/debug/deps/hasher-d3eebb0425cb74a6

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/test_nil_data-1f4bba3572a01eea

running 3 tests
test test_blake2b ... ok
test test_sm3 ... ok
test test_keccak ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests hasher

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


```